### PR TITLE
fix a bug with 'assignContent' on the jQuery flow

### DIFF
--- a/source/Pict-Content-Assignment.js
+++ b/source/Pict-Content-Assignment.js
@@ -100,18 +100,29 @@ class PictContentAssignment extends libFableServiceBase
 		}
 		else if (this.hasJquery)
 		{
-			// Get the element
-			let tmpTargetElement = window.jQuery(pAddress);
+			// Get the element(s)
+			let tmpTargetElementSet = window.jQuery(pAddress);
 
-			// Should we ensure we matched 1 and exactly 1 element?
-			//if (tmpTargetElement && tmpTargetElement.length == 1)
-			//{
-			// Set the content
-			tmpTargetElement.html(pContent);
-			//}
+			for (let i = 0; i < tmpTargetElementSet.length; i++)
+			{
+				switch (tmpTargetElementSet[i].tagName)
+				{
+					case 'INPUT':
+					case 'SELECT':
+						tmpTargetElementSet[i].value = pContent;
+						break;
+					case 'TEXTAREA':
+					case 'SCRIPT':
+						tmpTargetElementSet[i].text = pContent;
+						break;
+					default:
+						tmpTargetElementSet[i].innerHTML = pContent;
+				}
+			}
 		}
 		else if (this.inBrowser && this.hasDocument)
 		{
+			// Get the element(s)
 			let tmpTargetElementSet = window.document.querySelectorAll(pAddress);
 
 			for (let i = 0; i < tmpTargetElementSet.length; i++)
@@ -119,17 +130,15 @@ class PictContentAssignment extends libFableServiceBase
 				switch (tmpTargetElementSet[i].tagName)
 				{
 					case 'INPUT':
-					case 'BUTTON':
-					case 'TEXTAREA':
+					case 'SELECT':
 						tmpTargetElementSet[i].value = pContent;
 						break;
+					case 'TEXTAREA':
 					case 'SCRIPT':
-					case 'A':
 						tmpTargetElementSet[i].text = pContent;
 						break;
 					default:
 						tmpTargetElementSet[i].innerHTML = pContent;
-						break;
 				}
 			}
 		}

--- a/test/Pict_contentassignment_tests.js
+++ b/test/Pict_contentassignment_tests.js
@@ -31,7 +31,24 @@ suite
 			{
 				test
 				(
-					'Set content into an address',
+					'Set, read, and replace some content at an address',
+					(fDone) =>
+					{
+						let testPict = new libPict(_MockSettings);
+						let testEnvironment = new libPict.EnvironmentObject(testPict);
+
+						let tmpBox = testPict.ContentAssignment.assignContent('#MyBox', 'toy');
+						tmpBox = testPict.ContentAssignment.readContent('#MyBox');
+						Expect(tmpBox).to.equal('toy');
+						tmpBox = testPict.ContentAssignment.assignContent('#MyBox', '');
+						Expect(tmpBox).to.equal('');
+						fDone();
+					}
+				);
+
+				test
+				(
+					'Set, read, and remove an attribute at an address',
 					(fDone) =>
 					{
 						let testPict = new libPict(_MockSettings);
@@ -51,7 +68,7 @@ suite
 
 				test
 				(
-					'Check an element for a class name, then add and remove classes',
+					'Set, read, and remove a class at an address',
 					(fDone) =>
 					{
 						let testPict = new libPict(_MockSettings);


### PR DESCRIPTION
- Input and Select need to set the 'value'
- Script and Textarea need to set the 'text'
- Everything else can set 'html' (which includes 'text' and 'values')
- Added a basic assignment test