### PR TITLE
Add DataWithTempalteFallback expression + tests

### DIFF
--- a/source/Pict.js
+++ b/source/Pict.js
@@ -402,6 +402,8 @@ class Pict extends libFable {
 			//{~D:AppData.Some.Value.to.Render~}
 			this.addTemplate(require(`./templates/Pict-Template-Data.js`));
 
+			this.addTemplate(require(`./templates/Pict-Template-DataWithTemplateFallback.js`));
+
 			this.addTemplate(require(`./templates/Pict-Template-TemplateByReference.js`));
 
 			this.addTemplate(require(`./templates/Pict-Template-DataValueByKey.js`));

--- a/source/templates/Pict-Template-DataWithTemplateFallback.js
+++ b/source/templates/Pict-Template-DataWithTemplateFallback.js
@@ -34,11 +34,11 @@ class PictTemplateProviderData extends libPictTemplate
 
 		if (this.pict.LogNoisiness > 4)
 		{
-			this.log.trace(`PICT Template [fDataRender]::[${tmpHash}] with tmpData:`, tmpRecord);
+			this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] with tmpData:`, tmpRecord);
 		}
 		else if (this.pict.LogNoisiness > 3)
 		{
-			this.log.trace(`PICT Template [fDataRender]::[${tmpHash}]`);
+			this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}]`);
 		}
 
 		let tmpTemplateFallbackAddress = '';
@@ -52,24 +52,100 @@ class PictTemplateProviderData extends libPictTemplate
 		if (tmpHash != null)
 		{
 			tmpValue = this.resolveStateFromAddress(tmpHash, tmpRecord, pContextArray);
+
+			if (tmpValue && tmpValue !== 'undefined')
+			{
+				if (this.pict.LogNoisiness > 3)
+				{
+					this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] - Found value: ${tmpValue}`);
+					// If a value is found, return it
+					return tmpValue;
+				}
+				return tmpValue;
+			}
 		}
-		if ((tmpValue == null) || (tmpValue == 'undefined') || (typeof(tmpValue) == 'undefined') || (tmpValue === ''))
+		// If the value is not found or is undefined, try to use the fallback template
+		const tmpFallbackTemplate = this.pict.parseTemplateByHash(tmpTemplateFallbackAddress, tmpRecord, null, pContextArray);
+		if (tmpFallbackTemplate == null || tmpFallbackTemplate === '')
 		{
-			const tmpDefaultTemplate = this.pict.parseTemplateByHash(tmpTemplateFallbackAddress, tmpRecord, null, pContextArray);
-			if (tmpDefaultTemplate == null || tmpDefaultTemplate === '')
-			{
-				this.log.warn(`PICT Template [fDataRender]::[${tmpHash}] - No default template found at address: ${tmpTemplateFallbackAddress}`);
-				// If no default template is found, return an empty string
-				return '';
-			}
-			if (this.pict.LogNoisiness > 3)
-			{
-				this.log.trace(`PICT Template [fDataRender]::[${tmpHash}] - Using default template from address: ${tmpTemplateFallbackAddress}`);
-			}
-			return tmpDefaultTemplate;
+			this.log.warn(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] - No default template found at address: ${tmpTemplateFallbackAddress}`);
+			// If no default template is found, return an empty string
+			return '';
 		}
-		return tmpValue;
+		if (this.pict.LogNoisiness > 3)
+		{
+			this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] - Using default template from address: ${tmpTemplateFallbackAddress}`);
+		}
+		return tmpFallbackTemplate;
 	}
+
+	/**
+	 * Render a template expression asynchronously, returning a string with the resulting content or an optional default template string from an address.
+	 *
+	 * @param {string} pTemplateHash - The hash contents of the template (what's between the template start and stop tags)
+	 * @param {any} pRecord - The json object to be used as the Record for the template render
+	 * @param {function} fCallback - The callback function to be called with the result
+	 * @param {Array<any>} pContextArray - An array of context objects accessible from the template; safe to leave empty
+	 *
+	 * @return {void} The result is passed to the callback function
+	 */
+	renderAsync(pTemplateHash, pRecord, fCallback, pContextArray)
+	{
+		let tmpHash = pTemplateHash.trim();
+		let tmpData = (typeof (pRecord) === 'object') ? pRecord : {};
+		let tmpCallback = (typeof (fCallback) === 'function') ? fCallback : () => { return ''; };
+
+		if (this.pict.LogNoisiness > 4)
+		{
+			this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] with tmpData:`, tmpData);
+		}
+		else if (this.pict.LogNoisiness > 3)
+		{
+			this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}]`);
+		}
+
+		let tmpTemplateFallbackAddress = '';
+		if (tmpHash.indexOf(':') > -1)
+		{
+			tmpTemplateFallbackAddress = tmpHash.split(':')[1];
+			tmpHash = tmpHash.split(':')[0];
+		}
+
+		let tmpValue = '';
+		if (tmpHash != null)
+		{
+			tmpValue = this.resolveStateFromAddress(tmpHash, tmpData, pContextArray);
+
+			if (tmpValue && tmpValue !== 'undefined')
+			{
+				if (this.pict.LogNoisiness > 3)
+				{
+					this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] - Found value: ${tmpValue}`);
+				}
+				return tmpCallback(null, tmpValue);
+			}
+		}
+		// If the value is not found or is undefined, try to use the fallback template
+		this.pict.parseTemplateByHash(tmpTemplateFallbackAddress, tmpData, (pError, pValue) =>
+			{
+				if (pError)
+				{
+					return tmpCallback(pError, '');
+				}
+				if (pValue == null || pValue === '')
+				{
+					this.log.warn(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] - No fallback template found at address: ${tmpTemplateFallbackAddress}`);
+					// If no fallback template is found, return an empty string
+					return tmpCallback(null, '');
+				}
+				if (this.pict.LogNoisiness > 3)
+				{
+					this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] - Using fallback template from address: ${tmpTemplateFallbackAddress}`);
+				}
+				return tmpCallback(null, pValue);
+			}, pContextArray);
+	}
+
 }
 
 module.exports = PictTemplateProviderData;

--- a/source/templates/Pict-Template-DataWithTemplateFallback.js
+++ b/source/templates/Pict-Template-DataWithTemplateFallback.js
@@ -14,12 +14,12 @@ class PictTemplateProviderData extends libPictTemplate
 		/** @type {any} */
 		this.log;
 
-		this.addPattern('{~Data:', '~}');
-		this.addPattern('{~D:', '~}');
+		this.addPattern('{~DataWithTemplateFallback:', '~}');
+		this.addPattern('{~DWTF:', '~}');
 	}
 
 	/**
-	 * Render a template expression, returning a string with the resulting content or an optional default value.
+	 * Render a template expression, returning a string with the resulting content or an optional default template string from an address.
 	 *
 	 * @param {string} pTemplateHash - The hash contents of the template (what's between the template start and stop tags)
 	 * @param {any} pRecord - The json object to be used as the Record for the template render
@@ -41,10 +41,10 @@ class PictTemplateProviderData extends libPictTemplate
 			this.log.trace(`PICT Template [fDataRender]::[${tmpHash}]`);
 		}
 
-		let tmpDefaultValue = '';
+		let tmpTemplateFallbackAddress = '';
 		if (tmpHash.indexOf(':') > -1)
 		{
-			tmpDefaultValue = tmpHash.split(':')[1];
+			tmpTemplateFallbackAddress = tmpHash.split(':')[1];
 			tmpHash = tmpHash.split(':')[0];
 		}
 
@@ -55,7 +55,18 @@ class PictTemplateProviderData extends libPictTemplate
 		}
 		if ((tmpValue == null) || (tmpValue == 'undefined') || (typeof(tmpValue) == 'undefined') || (tmpValue === ''))
 		{
-			return tmpDefaultValue;
+			const tmpDefaultTemplate = this.pict.parseTemplateByHash(tmpTemplateFallbackAddress, tmpRecord, null, pContextArray);
+			if (tmpDefaultTemplate == null || tmpDefaultTemplate === '')
+			{
+				this.log.warn(`PICT Template [fDataRender]::[${tmpHash}] - No default template found at address: ${tmpTemplateFallbackAddress}`);
+				// If no default template is found, return an empty string
+				return '';
+			}
+			if (this.pict.LogNoisiness > 3)
+			{
+				this.log.trace(`PICT Template [fDataRender]::[${tmpHash}] - Using default template from address: ${tmpTemplateFallbackAddress}`);
+			}
+			return tmpDefaultTemplate;
 		}
 		return tmpValue;
 	}

--- a/source/templates/Pict-Template-DataWithTemplateFallback.js
+++ b/source/templates/Pict-Template-DataWithTemplateFallback.js
@@ -34,7 +34,7 @@ class PictTemplateProviderData extends libPictTemplate
 
 		if (this.pict.LogNoisiness > 4)
 		{
-			this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] with tmpData:`, tmpRecord);
+			this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] with tmpRecord:`, tmpRecord);
 		}
 		else if (this.pict.LogNoisiness > 3)
 		{
@@ -61,30 +61,29 @@ class PictTemplateProviderData extends libPictTemplate
 					// If a value is found, return it
 					return tmpValue;
 				}
-				return tmpValue;
 			}
 		}
 		// If the value is not found or is undefined, try to use the fallback template
 		const tmpFallbackTemplate = this.pict.parseTemplateByHash(tmpTemplateFallbackAddress, tmpRecord, null, pContextArray);
 		if (tmpFallbackTemplate == null || tmpFallbackTemplate === '')
 		{
-			this.log.warn(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] - No default template found at address: ${tmpTemplateFallbackAddress}`);
-			// If no default template is found, return an empty string
+			this.log.warn(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] - No fallback template found at address: ${tmpTemplateFallbackAddress}`);
+			// If no fallback template is found, return an empty string
 			return '';
 		}
 		if (this.pict.LogNoisiness > 3)
 		{
-			this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] - Using default template from address: ${tmpTemplateFallbackAddress}`);
+			this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] - Using fallback template from address: ${tmpTemplateFallbackAddress}`);
 		}
 		return tmpFallbackTemplate;
 	}
 
 	/**
-	 * Render a template expression asynchronously, returning a string with the resulting content or an optional default template string from an address.
+	 * Render a template expression asynchronously, returning a string with the resulting content or an optional fallback template string from an address.
 	 *
 	 * @param {string} pTemplateHash - The hash contents of the template (what's between the template start and stop tags)
 	 * @param {any} pRecord - The json object to be used as the Record for the template render
-	 * @param {function} fCallback - The callback function to be called with the result
+	 * @param {(pError?: Error, pResult?: string) => void} fCallback - The callback function to be called with the result
 	 * @param {Array<any>} pContextArray - An array of context objects accessible from the template; safe to leave empty
 	 *
 	 * @return {void} The result is passed to the callback function
@@ -92,12 +91,12 @@ class PictTemplateProviderData extends libPictTemplate
 	renderAsync(pTemplateHash, pRecord, fCallback, pContextArray)
 	{
 		let tmpHash = pTemplateHash.trim();
-		let tmpData = (typeof (pRecord) === 'object') ? pRecord : {};
+		let tmpRecord = (typeof (pRecord) === 'object') ? pRecord : {};
 		let tmpCallback = (typeof (fCallback) === 'function') ? fCallback : () => { return ''; };
 
 		if (this.pict.LogNoisiness > 4)
 		{
-			this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] with tmpData:`, tmpData);
+			this.log.trace(`PICT DataWithTemplateFallback [fDataRender]::[${tmpHash}] with tmpRecord:`, tmpRecord);
 		}
 		else if (this.pict.LogNoisiness > 3)
 		{
@@ -114,7 +113,7 @@ class PictTemplateProviderData extends libPictTemplate
 		let tmpValue = '';
 		if (tmpHash != null)
 		{
-			tmpValue = this.resolveStateFromAddress(tmpHash, tmpData, pContextArray);
+			tmpValue = this.resolveStateFromAddress(tmpHash, tmpRecord, pContextArray);
 
 			if (tmpValue && tmpValue !== 'undefined')
 			{
@@ -126,7 +125,7 @@ class PictTemplateProviderData extends libPictTemplate
 			}
 		}
 		// If the value is not found or is undefined, try to use the fallback template
-		this.pict.parseTemplateByHash(tmpTemplateFallbackAddress, tmpData, (pError, pValue) =>
+		this.pict.parseTemplateByHash(tmpTemplateFallbackAddress, tmpRecord, (pError, pValue) =>
 			{
 				if (pError)
 				{

--- a/test/Pict_template_tests.js
+++ b/test/Pict_template_tests.js
@@ -456,6 +456,39 @@ suite(
 								}
 							);
 						test(
+								'Data template rendering with missing data and a template fallback...',
+								function (fDone)
+								{
+									const testPict = new libPict(_MockSettings);
+
+									testPict.TemplateProvider.addTemplate('Book-Author-Title', '<h1>{~DWTF:Record.Title:MissingTitle~}</h1>');
+									testPict.TemplateProvider.addTemplate('MissingTitle', '<span class="empty-message">Oh no! No title!</span>');
+
+									testPict.parseTemplateByHash('Book-Author-Title', { Title: undefined },
+										(pError, pValue) =>
+										{
+											Expect(pValue).to.equal('<h1><span class="empty-message">Oh no! No title!</span></h1>');
+											return fDone();
+										});
+								}
+							);
+						test(
+								'Data template rendering with missing data and a template fallback, but the fallback address is not found...',
+								function (fDone)
+								{
+									const testPict = new libPict(_MockSettings);
+
+									testPict.TemplateProvider.addTemplate('Book-Author-Title', '<h1>{~DWTF:Record.Title:IntentionallyMissingFallbackTemplate~}</h1>');
+
+									testPict.parseTemplateByHash('Book-Author-Title', { Title: undefined },
+										(pError, pValue) =>
+										{
+											Expect(pValue).to.equal('<h1></h1>');
+											return fDone();
+										});
+								}
+							);
+						test(
 								'Entity template rendering...',
 								function (fDone)
 								{

--- a/test/Pict_template_tests.js
+++ b/test/Pict_template_tests.js
@@ -101,6 +101,7 @@ suite(
 								{
 									const testPict = new libPict(_MockSettings);
 									let tmpTemplateOutput = testPict.parseTemplate('{~DEJS:Record.MagicDate~}', { MagicDate: 'These quotes " should not be unescaped...' });
+									// eslint-disable-next-line no-useless-escape
 									Expect(tmpTemplateOutput).to.equal(`These quotes \" should not be unescaped...`);
 									fDone();
 								}

--- a/test/Pict_template_tests.js
+++ b/test/Pict_template_tests.js
@@ -489,6 +489,25 @@ suite(
 								}
 							);
 						test(
+								'Data template rendering with missing data and a template fallback that has async entity data...',
+								function (fDone)
+								{
+									const testPict = new libPict(_MockSettings);
+
+									testPict.TemplateProvider.addTemplate('Book-Author-Title', '<h1>{~DWTF:Record.Banana:MissingBanana~}: {~Dollars:Record.IDBook~}</h1>');
+									testPict.TemplateProvider.addTemplate('Book-Author-Content', '<p>{~E:Book^1^Book-Author-Title~}</p>');
+									testPict.TemplateProvider.addTemplate('Book-Author-Load', '<p>{~E:Book^100^Book-Author-Title~} {~D:Record.itemnumber~}</p>');
+									testPict.TemplateProvider.addTemplate('MissingBanana', '<span class="empty-message">Oh no! No banana!</span>');
+
+									testPict.parseTemplateByHash('Book-Author-Content', { IDBook: 100 },
+										(pError, pValue) =>
+										{
+											Expect(pValue).to.equal('<p><h1><span class="empty-message">Oh no! No banana!</span>: $1.00</h1></p>');
+											return fDone();
+										});
+								}
+							);
+						test(
 								'Entity template rendering...',
 								function (fDone)
 								{


### PR DESCRIPTION
A new DataWithTemplateFallback (DTWF) expression to show Data or fallback to a template by way of address for shared/repeatable fallback templates for nicer looking empty/not-found UIs.